### PR TITLE
Issue #46: Explicitly define "local_cohortauto_handler" class variables

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -114,6 +114,16 @@ class local_cohortauto_handler {
     const COMPONENT_NAME = 'local_cohortauto';
 
     /**
+     * @var stdClass Plugin configuration
+     */
+    protected $config;
+
+    /**
+     * @var Mustache_Engine Mustache Engine instance
+     */
+    protected $mustache;
+
+    /**
      * Constructor.
      */
     public function __construct() {


### PR DESCRIPTION
cherry picking from fix alreayd merged into 405 branch, its a php 8.3 bug, so also applies to 4.4 sites, since its a undeclared variable bug no issues with backwards compadability